### PR TITLE
[ADD] feat: Add database connection module

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,2 @@
+name: Publish Python Package to PyPI
+

--- a/pyntegritydb/connect.py
+++ b/pyntegritydb/connect.py
@@ -1,37 +1,54 @@
-from sqlalchemy import create_engine, Engine
-from sqlalchemy.exc import OperationalError
+from sqlalchemy import create_engine, inspect
+from sqlalchemy.engine import Engine
+from sqlalchemy.exc import SQLAlchemyError
 
-def create_engine_from_uri(uri: str) -> Engine | None:
+def create_db_engine(uri: str) -> Engine:
     """
-    Creates a SQLAlchemy engine from a database URI.
+    Crea y valida un motor de SQLAlchemy a partir de una URI de conexión.
 
-    Parameters:
-        uri (str): Database connection URI.
+    Esta función toma una URI estándar de base de datos, intenta establecer una
+    conexión y, si tiene éxito, devuelve un motor de SQLAlchemy listo para ser
+    utilizado por otros módulos de la biblioteca.
+
+    Args:
+        uri: La URI de la base de datos (ej. "postgresql://user:pass@host/db").
 
     Returns:
-        engine (sqlalchemy.Engine): SQLAlchemy engine object.
+        Una instancia del motor de SQLAlchemy si la conexión es exitosa.
+
+    Raises:
+        ValueError: Si la URI es inválida o la conexión falla, proporcionando
+                    un mensaje claro sobre la causa del error.
     """
+    if not isinstance(uri, str) or "://" not in uri:
+        raise ValueError("La URI de conexión proporcionada es inválida. El formato esperado es 'dialect+driver://user:pass@host/db'.")
+    
     try:
         engine = create_engine(uri)
+        # Intenta conectar para validar la URI, credenciales y disponibilidad de la BD.
+        # El bloque 'with' asegura que la conexión se cierre correctamente.
+        with engine.connect():
+            pass
+        
+        print(f"✅ Conexión exitosa al motor: {engine.dialect.name}")
         return engine
-    except OperationalError as e:
-        print(f"Connection failed: {e}")
-        return None
-    
-def test_connection(engine: Engine) -> bool:
-    """
-    Tests the connection to the database using the provided engine.
+    except SQLAlchemyError as e:
+        # Captura cualquier error de SQLAlchemy para dar un feedback más útil.
+        raise ValueError(f"❌ No se pudo conectar a la base de datos. Error: {e}") from e
 
-    Parameters:
-        engine (sqlalchemy.Engine): SQLAlchemy engine object.
+    
+def get_db_inspector(engine: Engine) -> object:
+    """
+    Obtiene un objeto inspector de SQLAlchemy para el motor dado.
+
+    El inspector es una herramienta de bajo nivel que permite extraer
+    metadatos del esquema de la base de datos, como tablas, columnas y
+    restricciones.
+
+    Args:
+        engine: Una instancia activa del motor de SQLAlchemy.
 
     Returns:
-        bool: True if connection is successful, False otherwise.
+        Un objeto Inspector.
     """
-    try:
-        with engine.connect() as conn:
-            conn.execute("SELECT 1")
-        return True
-    except Exception as e:
-        print(f"Connection test failed: {e}")
-        return False
+    return inspect(engine)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,11 +15,13 @@ classifiers = [
 ]
 dependencies = [
     "SQLAlchemy==2.0.43",
+    "psycopg2-binary==2.9.10"
 ]
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=7.0",
+    "pytest==8.4.1",
+    "mock==5.2.0",
     "ruff"
 ]
 docs = [

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -1,0 +1,52 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from sqlalchemy.exc import OperationalError
+
+from pyntegritydb.connect import create_db_engine
+
+def test_create_db_engine_success():
+    """
+    Prueba que el motor se crea exitosamente con una URI válida.
+    Utilizamos un 'mock' para simular SQLAlchemy y no requerir una BD real.
+    """
+    # Usamos patch para reemplazar 'create_engine' de SQLAlchemy con un mock
+    with patch('pyntegritydb.connect.create_engine') as mock_create_engine:
+        # Configuramos el mock para que se comporte como si la conexión fuera exitosa
+        mock_engine = MagicMock()
+        mock_engine.dialect.name = 'sqlite'
+        mock_create_engine.return_value = mock_engine
+
+        # La URI es para una base de datos en memoria (no se crea realmente)
+        uri = "sqlite:///:memory:"
+        engine = create_db_engine(uri)
+
+        # Verificamos que se llamó a create_engine con la URI correcta
+        mock_create_engine.assert_called_once_with(uri)
+        # Verificamos que el motor devuelto es el que simulamos
+        assert engine is not None
+        assert engine.dialect.name == 'sqlite'
+
+def test_create_db_engine_invalid_uri():
+    """
+    Prueba que se lanza un ValueError si la URI es claramente inválida.
+    """
+    # pytest.raises verifica que el código dentro del bloque 'with'
+    # lanza la excepción esperada.
+    with pytest.raises(ValueError, match="La URI de conexión proporcionada es inválida"):
+        create_db_engine("esto_no_es_una_uri")
+
+def test_create_db_engine_connection_failure():
+    """
+    Prueba que se lanza un ValueError si SQLAlchemy no puede conectar a la BD.
+    """
+    with patch('pyntegritydb.connect.create_engine') as mock_create_engine:
+        # Configuramos el mock para que falle al intentar conectar
+        mock_engine = MagicMock()
+        # Simulamos un error de conexión (ej. contraseña incorrecta)
+        mock_engine.connect.side_effect = OperationalError("test error", {}, "")
+        mock_create_engine.return_value = mock_engine
+
+        uri = "postgresql://user:wrong_pass@host/db"
+        
+        with pytest.raises(ValueError, match="No se pudo conectar a la base de datos"):
+            create_db_engine(uri)


### PR DESCRIPTION
### Resumen
Este PR introduce el módulo inicial de `pyntegritydb`: **`connect.py`**.

Este módulo establece la base de la biblioteca al proporcionar una manera estandarizada y robusta de conectarse a bases de datos a través de SQLAlchemy. Incluye validación de URI y manejo de errores para garantizar que las conexiones fallidas se informen claramente al usuario.

### Cambios Clave
- **`pyntegritydb/connect.py`**: Nuevo módulo con las funciones `create_db_engine` y `get_db_inspector`.
- **`tests/test_connect.py`**: Se añaden pruebas unitarias para el módulo de conexión, cubriendo:
    - Conexión exitosa (usando mocks).
    - Manejo de URI inválidas.
    - Manejo de fallos en la conexión.

### Cómo Probar
1.  Clona esta rama.
2.  Asegúrate de tener `pytest` y `pytest-mock` instalados.
3.  Ejecuta `pytest` desde el directorio raíz.
4.  Todas las pruebas en `tests/test_connect.py` deberían pasar. ✅