### PR TITLE
[ADD] feat: Add schema and graph extraction module

### DIFF
--- a/pyntegritydb/schema.py
+++ b/pyntegritydb/schema.py
@@ -1,0 +1,54 @@
+import networkx as nx
+from sqlalchemy.engine import Engine
+
+from .connect import get_db_inspector
+
+def get_schema_graph(engine: Engine) -> nx.DiGraph:
+    """
+    Extrae el esquema de la base de datos y lo representa como un grafo dirigido.
+
+    Cada nodo en el grafo es una tabla, y cada arco dirigido representa una
+    relación de clave foránea (FK), apuntando desde la tabla que contiene la FK
+    hacia la tabla que contiene la clave primaria (PK) referenciada.
+
+    Los detalles de la relación (columnas implicadas) se almacenan como
+    atributos en el arco.
+
+    Args:
+        engine: El motor de SQLAlchemy para la base de datos.
+
+    Returns:
+        Un grafo DiGraph de NetworkX que representa las relaciones FK del esquema.
+    """
+    inspector = get_db_inspector(engine)
+    schema_graph = nx.DiGraph()
+    
+    print("🔎 Extrayendo esquema de la base de datos...")
+    
+    # Itera sobre todos los esquemas disponibles (importante para BBDD como PostgreSQL)
+    for schema in inspector.get_schema_names():
+        # Obtiene las tablas para el esquema actual
+        for table_name in inspector.get_table_names(schema=schema):
+            # Añade cada tabla como un nodo en el grafo
+            schema_graph.add_node(table_name, type='table')
+            
+            # Obtiene las claves foráneas para la tabla actual
+            try:
+                fks = inspector.get_foreign_keys(table_name, schema=schema)
+                for fk in fks:
+                    # Añade un arco desde la tabla que referencia hacia la tabla referenciada
+                    schema_graph.add_edge(
+                        table_name, 
+                        fk['referred_table'], 
+                        # Almacena metadatos importantes en el arco para su uso posterior
+                        constrained_columns=fk['constrained_columns'],
+                        referred_columns=fk['referred_columns']
+                    )
+            except Exception as e:
+                print(f"⚠️ No se pudieron obtener las FKs para la tabla '{table_name}': {e}")
+
+    node_count = schema_graph.number_of_nodes()
+    edge_count = schema_graph.number_of_edges()
+    print(f"✅ Grafo construido: {node_count} tablas y {edge_count} relaciones encontradas.")
+    
+    return schema_graph

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ classifiers = [
 ]
 dependencies = [
     "SQLAlchemy==2.0.43",
-    "psycopg2-binary==2.9.10"
+    "psycopg2-binary==2.9.10",
+    "networkx==3.5"
 ]
 
 [project.optional-dependencies]

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,59 @@
+import pytest
+import networkx as nx
+from unittest.mock import MagicMock, patch
+
+from pyntegritydb.schema import get_schema_graph
+
+@pytest.fixture
+def mock_inspector():
+    """Crea un mock del inspector de SQLAlchemy para las pruebas."""
+    inspector = MagicMock()
+
+    # Define la estructura de la base de datos simulada
+    inspector.get_schema_names.return_value = ['public']
+    inspector.get_table_names.return_value = ['users', 'orders', 'products', 'categories']
+
+    # Define las claves foráneas simuladas
+    def get_fks_side_effect(table_name, schema=None):
+        if table_name == 'orders':
+            return [
+                {
+                    'constrained_columns': ['user_id'],
+                    'referred_table': 'users',
+                    'referred_columns': ['id']
+                },
+                {
+                    'constrained_columns': ['product_id'],
+                    'referred_table': 'products',
+                    'referred_columns': ['id']
+                }
+            ]
+        return []
+
+    inspector.get_foreign_keys.side_effect = get_fks_side_effect
+    return inspector
+
+def test_get_schema_graph_structure(mock_inspector):
+    """
+    Prueba que el grafo se construye correctamente a partir de un esquema simulado.
+    """
+    mock_engine = MagicMock() # No necesitamos un motor real, solo el inspector
+
+    # Sobrescribimos 'get_db_inspector' para que devuelva nuestro mock
+    with patch('pyntegritydb.schema.get_db_inspector', return_value=mock_inspector):
+        graph = get_schema_graph(mock_engine)
+
+    # Verificaciones sobre la estructura del grafo
+    assert isinstance(graph, nx.DiGraph), "El resultado debe ser un DiGraph de NetworkX"
+    assert graph.number_of_nodes() == 4, "Debe haber 4 tablas como nodos"
+    assert graph.number_of_edges() == 2, "Debe haber 2 relaciones FK como arcos"
+
+    # Verificaciones sobre las relaciones específicas
+    assert graph.has_edge('orders', 'users'), "Debe existir una relación de 'orders' a 'users'"
+    assert graph.has_edge('orders', 'products'), "Debe existir una relación de 'orders' a 'products'"
+    assert not graph.has_edge('users', 'orders'), "La relación no debe ser bidireccional"
+
+    # Verificación de los metadatos almacenados en el arco
+    edge_data = graph.get_edge_data('orders', 'users')
+    assert edge_data['constrained_columns'] == ['user_id']
+    assert edge_data['referred_columns'] == ['id']


### PR DESCRIPTION
### Resumen
Este PR introduce el módulo **`schema.py`**, que cumple una función central en `pyntegritydb`: inspeccionar una base de datos y construir un grafo de sus relaciones de integridad referencial.

Este módulo se encarga de:
1.  Extraer metadatos de tablas y claves foráneas usando SQLAlchemy.
2.  Construir un grafo dirigido (`DiGraph`) con la biblioteca `NetworkX`, donde los nodos son tablas y los arcos son las relaciones FK.
3.  Almacenar los detalles de las columnas de cada relación como atributos en los arcos del grafo, preparándolos para el futuro módulo de `metrics`.

### Cambios Clave
- **`pyntegritydb/schema.py`**: Nuevo módulo que contiene la lógica de extracción y construcción del grafo.
- **`tests/test_schema.py`**: Pruebas unitarias que verifican la correcta construcción del grafo a partir de un esquema simulado, asegurando que los nodos, arcos y sus atributos se creen correctamente.

### Cómo Probar
1.  Asegúrate de tener `pytest` y `networkx` instalados.
2.  Ejecuta `pytest` desde el directorio raíz del proyecto.
3.  Todas las pruebas en `tests/test_schema.py` deben pasar con éxito. ✅