### PR TITLE
[ADD] feat: Implement metrics calculation module

### DIFF
--- a/pyntegritydb/metrics.py
+++ b/pyntegritydb/metrics.py
@@ -1,0 +1,129 @@
+import pandas as pd
+import networkx as nx
+from sqlalchemy.engine import Engine
+from sqlalchemy import text
+
+def _calculate_fk_completeness(
+    engine: Engine, 
+    referencing_table: str, 
+    referencing_columns: list, 
+    referenced_table: str, 
+    referenced_columns: list
+) -> dict:
+    """
+    Función auxiliar que calcula las métricas para una única relación FK.
+    
+    Ejecuta una única consulta SQL optimizada con LEFT JOIN para obtener
+    los conteos necesarios y luego calcula las tasas y densidades.
+    """
+    # Construcción robusta de la consulta para manejar claves simples y compuestas
+    join_condition = " AND ".join(
+        f't1."{ref_col}" = t2."{pk_col}"'
+        for ref_col, pk_col in zip(referencing_columns, referenced_columns)
+    )
+    
+    # Una fila es huérfana si, tras el join, la PK de la tabla referenciada es NULL
+    orphan_condition = " OR ".join(f't2."{pk_col}" IS NULL' for pk_col in referenced_columns)
+    
+    # Una FK es nula si cualquiera de sus columnas en la tabla de origen es NULL
+    null_fk_condition = " OR ".join(f't1."{ref_col}" IS NULL' for ref_col in referencing_columns)
+
+    query = text(f"""
+    SELECT
+        COUNT(*) AS total_rows,
+        COUNT(CASE WHEN {orphan_condition} THEN 1 END) AS orphan_rows,
+        COUNT(CASE WHEN {null_fk_condition} THEN 1 END) AS null_rows
+    FROM
+        "{referencing_table}" AS t1
+    LEFT JOIN
+        "{referenced_table}" AS t2 ON {join_condition}
+    """)
+    
+    try:
+        with engine.connect() as connection:
+            result = connection.execute(query).mappings().first()
+    except Exception as e:
+        print(f"❌ Error al ejecutar la consulta para {referencing_table} -> {referenced_table}: {e}")
+        return {
+            'error': str(e)
+        }
+
+    total_rows = result.get('total_rows', 0)
+    orphan_rows = result.get('orphan_rows', 0)
+    null_rows = result.get('null_rows', 0)
+    
+    # Evitar división por cero si la tabla está vacía
+    if total_rows == 0:
+        return {
+            'total_rows': 0,
+            'orphan_rows_count': 0,
+            'valid_rows_count': 0,
+            'null_rows_count': 0,
+            'orphan_rate': 0.0,
+            'validity_rate': 1.0,
+            'fk_density': 1.0,
+        }
+        
+    valid_rows = total_rows - orphan_rows
+    
+    return {
+        'total_rows': total_rows,
+        'orphan_rows_count': orphan_rows,
+        'valid_rows_count': valid_rows,
+        'null_rows_count': null_rows,
+        'orphan_rate': orphan_rows / total_rows,
+        'validity_rate': valid_rows / total_rows,
+        'fk_density': (total_rows - null_rows) / total_rows,
+    }
+
+
+def analyze_database_completeness(engine: Engine, schema_graph: nx.DiGraph) -> pd.DataFrame:
+    """
+    Analiza todas las relaciones FK en el grafo y calcula sus métricas de completitud.
+
+    Itera sobre cada arco del grafo, invoca al calculador de métricas y consolida
+    los resultados en un único DataFrame de Pandas.
+
+    Args:
+        engine: El motor de SQLAlchemy.
+        schema_graph: El grafo del esquema de la base de datos.
+
+    Returns:
+        Un DataFrame de Pandas con los resultados de las métricas para cada FK.
+    """
+    results = []
+    
+    print(f"\n🚀 Analizando {schema_graph.number_of_edges()} relaciones...")
+    
+    for u, v, data in schema_graph.edges(data=True):
+        referencing_table = u
+        referenced_table = v
+        
+        print(f"  -> Calculando: {referencing_table} -> {referenced_table}")
+        
+        metrics = _calculate_fk_completeness(
+            engine,
+            referencing_table,
+            data['constrained_columns'],
+            referenced_table,
+            data['referred_columns']
+        )
+        
+        if 'error' in metrics:
+            # Si hubo un error, se añade a los resultados para informar al usuario
+            results.append({
+                'referencing_table': referencing_table,
+                'referenced_table': referenced_table,
+                'fk_columns': ', '.join(data['constrained_columns']),
+                'error': metrics['error'],
+            })
+        else:
+            results.append({
+                'referencing_table': referencing_table,
+                'referenced_table': referenced_table,
+                'fk_columns': ', '.join(data['constrained_columns']),
+                **metrics
+            })
+            
+    print("✅ Análisis completado.")
+    return pd.DataFrame(results)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ classifiers = [
 dependencies = [
     "SQLAlchemy==2.0.43",
     "psycopg2-binary==2.9.10",
-    "networkx==3.5"
+    "networkx==3.5",
+    "pandas==2.3.1"
 ]
 
 [project.optional-dependencies]

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,66 @@
+import pytest
+import pandas as pd
+import networkx as nx
+from unittest.mock import MagicMock, patch
+
+from pyntegritydb.metrics import _calculate_fk_completeness, analyze_database_completeness
+
+@pytest.fixture
+def mock_engine_connect():
+    """Fixture que simula una conexión y un resultado de consulta exitoso."""
+    # Simula el objeto 'result' que devuelve SQLAlchemy
+    mock_result = MagicMock()
+    mock_result.mappings.return_value.first.return_value = {
+        'total_rows': 100,
+        'orphan_rows': 5,
+        'null_rows': 10
+    }
+    
+    # Simula el gestor de contexto 'with engine.connect() as connection:'
+    mock_connection = MagicMock()
+    mock_connection.__enter__.return_value.execute.return_value = mock_result
+    
+    mock_engine = MagicMock()
+    mock_engine.connect.return_value = mock_connection
+    return mock_engine
+
+def test_calculate_fk_completeness_logic(mock_engine_connect):
+    """
+    Prueba la lógica de cálculo de la función auxiliar con datos simulados.
+    """
+    metrics = _calculate_fk_completeness(
+        mock_engine_connect, "orders", ["user_id"], "users", ["id"]
+    )
+
+    assert metrics['total_rows'] == 100
+    assert metrics['orphan_rows_count'] == 5
+    assert metrics['valid_rows_count'] == 95
+    assert metrics['null_rows_count'] == 10
+    assert metrics['orphan_rate'] == 0.05
+    assert metrics['validity_rate'] == 0.95
+    assert metrics['fk_density'] == 0.90
+
+def test_analyze_database_completeness_flow():
+    """
+    Prueba el flujo de la función principal: que itere el grafo y devuelva un DataFrame.
+    """
+    # 1. Crear un grafo de prueba
+    test_graph = nx.DiGraph()
+    test_graph.add_edge(
+        "orders", "users", 
+        constrained_columns=["user_id"], referred_columns=["id"]
+    )
+    
+    # 2. Simular la función de cálculo para que siempre devuelva lo mismo
+    mock_metrics_result = {'total_rows': 100, 'validity_rate': 0.95}
+    
+    # 3. 'patch' para reemplazar la función de cálculo real por nuestro mock
+    with patch('pyntegritydb.metrics._calculate_fk_completeness', return_value=mock_metrics_result) as mock_calculator:
+        df_results = analyze_database_completeness(MagicMock(), test_graph)
+
+        # 4. Verificaciones
+        mock_calculator.assert_called_once() # Verificar que se llamó al calculador
+        assert isinstance(df_results, pd.DataFrame)
+        assert len(df_results) == 1 # Debe haber una fila por cada relación en el grafo
+        assert df_results.iloc[0]['referencing_table'] == 'orders'
+        assert df_results.iloc[0]['validity_rate'] == 0.95


### PR DESCRIPTION
### Resumen
Este PR introduce el **módulo `metrics.py`**, el núcleo de análisis de `pyntegritydb`. 🚀

Este módulo se encarga de:
1.  Iterar sobre cada relación de clave foránea (arco) del grafo de esquema.
2.  Construir y ejecutar una consulta SQL optimizada (`LEFT JOIN`) para cada relación, capaz de manejar claves compuestas.
3.  Calcular un conjunto de métricas de integridad referencial, incluyendo:
    - `validity_rate`
    - `orphan_rate`
    - `fk_density`
4.  Consolidar todos los resultados en un único **DataFrame de Pandas** para facilitar su posterior reporte y análisis.

### Cambios Clave
- **`pyntegritydb/metrics.py`**: Nuevo módulo que contiene la lógica de cálculo.
- **`tests/test_metrics.py`**: Pruebas unitarias que validan tanto la lógica de cálculo con datos simulados como el flujo general de la función principal.

### Cómo Probar
1.  Asegúrate de tener `pytest` y `pandas` instalados.
2.  Ejecuta `pytest` desde el directorio raíz del proyecto.
3.  Todas las pruebas en `tests/test_metrics.py` deben pasar con éxito. ✅