### PR TITLE
[ADD] feat: Add multi-format report generation module

### DIFF
--- a/pyntegritydb/report.py
+++ b/pyntegritydb/report.py
@@ -1,0 +1,72 @@
+# pyntegritydb/report.py
+
+import json
+import pandas as pd
+from tabulate import tabulate
+
+def _format_cli(df: pd.DataFrame) -> str:
+    """Formatea los resultados en una tabla bonita para la línea de comandos."""
+    if df.empty:
+        return "No se encontraron relaciones para analizar."
+
+    # Seleccionar y renombrar columnas para una mejor legibilidad
+    display_df = df.copy()
+    display_df['validity_rate'] = (display_df['validity_rate'] * 100).map('{:.2f}%'.format)
+    display_df['orphan_rate'] = (display_df['orphan_rate'] * 100).map('{:.2f}%'.format)
+    display_df['fk_density'] = (display_df['fk_density'] * 100).map('{:.2f}%'.format)
+    
+    headers = {
+        'referencing_table': 'Tabla de Origen',
+        'referenced_table': 'Tabla de Destino',
+        'validity_rate': 'Tasa de Validez',
+        'orphan_rows_count': 'Filas Huérfanas',
+        'total_rows': 'Total Filas'
+    }
+    
+    display_df = display_df[headers.keys()].rename(columns=headers)
+    
+    # Crear la tabla usando tabulate
+    table = tabulate(display_df, headers='keys', tablefmt='grid', showindex=False)
+    
+    # Añadir un resumen
+    total_relations = len(df)
+    relations_with_orphans = len(df[df['orphan_rows_count'] > 0])
+    summary = (
+        f"\nResumen del Análisis:\n"
+        f"---------------------\n"
+        f"Relaciones analizadas: {total_relations}\n"
+        f"Relaciones con filas huérfanas: {relations_with_orphans}\n"
+    )
+    
+    return table + summary
+
+def _format_json(df: pd.DataFrame) -> str:
+    """Convierte los resultados a un formato JSON (lista de objetos)."""
+    return df.to_json(orient='records', indent=4)
+
+def _format_csv(df: pd.DataFrame) -> str:
+    """Convierte los resultados a formato CSV."""
+    return df.to_csv(index=False)
+
+def generate_report(df: pd.DataFrame, report_format: str = 'cli') -> str:
+    """
+    Genera un reporte de los resultados de las métricas en el formato especificado.
+
+    Args:
+        df: DataFrame de Pandas con los resultados del módulo de métricas.
+        report_format: El formato de salida ('cli', 'json', 'csv').
+
+    Returns:
+        Una cadena de texto con el reporte formateado.
+        
+    Raises:
+        ValueError: Si el formato de reporte no es soportado.
+    """
+    if report_format == 'cli':
+        return _format_cli(df)
+    elif report_format == 'json':
+        return _format_json(df)
+    elif report_format == 'csv':
+        return _format_csv(df)
+    else:
+        raise ValueError(f"Formato de reporte no soportado: '{report_format}'. Opciones válidas: 'cli', 'json', 'csv'.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,8 @@ dependencies = [
     "SQLAlchemy==2.0.43",
     "psycopg2-binary==2.9.10",
     "networkx==3.5",
-    "pandas==2.3.1"
+    "pandas==2.3.1",
+    "tabulate==0.9.0"
 ]
 
 [project.optional-dependencies]

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,56 @@
+import pytest
+import pandas as pd
+import json
+
+from pyntegritydb.report import generate_report
+
+@pytest.fixture
+def sample_metrics_df():
+    """Crea un DataFrame de ejemplo para usar en las pruebas."""
+    data = {
+        'referencing_table': ['orders', 'order_items'],
+        'referenced_table': ['users', 'products'],
+        'fk_columns': ['user_id', 'product_id'],
+        'total_rows': [1000, 5000],
+        'orphan_rows_count': [50, 0],
+        'valid_rows_count': [950, 5000],
+        'null_rows_count': [10, 20],
+        'orphan_rate': [0.05, 0.0],
+        'validity_rate': [0.95, 1.0],
+        'fk_density': [0.99, 0.996]
+    }
+    return pd.DataFrame(data)
+
+def test_generate_report_cli_format(sample_metrics_df):
+    """Prueba que el formato CLI se genere y contenga los datos clave."""
+    report = generate_report(sample_metrics_df, 'cli')
+    assert isinstance(report, str)
+    assert 'Tasa de Validez' in report
+    assert '95.00%' in report  # Verifica que el formato de porcentaje se aplicó
+    assert 'orders' in report
+    assert 'Resumen del Análisis' in report
+
+def test_generate_report_json_format(sample_metrics_df):
+    """Prueba que el formato JSON sea válido y contenga los datos correctos."""
+    report = generate_report(sample_metrics_df, 'json')
+    data = json.loads(report)
+    
+    assert isinstance(data, list)
+    assert len(data) == 2
+    assert data[0]['referencing_table'] == 'orders'
+    assert data[0]['validity_rate'] == 0.95
+
+def test_generate_report_csv_format(sample_metrics_df):
+    """Prueba que el formato CSV se genere con el encabezado y datos correctos."""
+    report = generate_report(sample_metrics_df, 'csv')
+    
+    assert isinstance(report, str)
+    lines = report.strip().split('\n')
+    assert len(lines) == 3  # 1 encabezado + 2 filas de datos
+    assert lines[0] == 'referencing_table,referenced_table,fk_columns,total_rows,orphan_rows_count,valid_rows_count,null_rows_count,orphan_rate,validity_rate,fk_density'
+    assert lines[1].startswith('orders,users,user_id')
+
+def test_generate_report_unsupported_format(sample_metrics_df):
+    """Prueba que se lance un ValueError para un formato no soportado."""
+    with pytest.raises(ValueError, match="Formato de reporte no soportado: 'xml'"):
+        generate_report(sample_metrics_df, 'xml')


### PR DESCRIPTION
### Resumen
Este PR introduce el módulo **`report.py`**, encargado de la presentación de los resultados del análisis. Transforma el DataFrame de métricas en formatos legibles tanto para humanos como para otras aplicaciones.

La funcionalidad principal es la capacidad de generar reportes en múltiples formatos:
- **`cli`**: Una tabla bien formateada para la consola, ideal para uso interactivo.
- **`json`**: Salida estructurada, perfecta para la integración con APIs y herramientas de automatización.
- **`csv`**: Formato estándar para auditorías y análisis de datos en hojas de cálculo.

### Cambios Clave
- **`pyntegritydb/report.py`**: Nuevo módulo con la lógica de formateo.
- **`tests/test_report.py`**: Pruebas unitarias que aseguran que cada formato de salida se genere correctamente.
- **Dependencias**: Se añade `tabulate` a las dependencias del proyecto para la generación de tablas en la CLI.

### Cómo Probar
1.  Instala las nuevas dependencias (`pip install tabulate`).
2.  Ejecuta `pytest` desde el directorio raíz.
3.  Todas las pruebas en `tests/test_report.py` deben pasar. ✅