### PR TITLE
[ADD] feat: Add command-line interface (CLI).

### DIFF
--- a/pyntegritydb/cli.py
+++ b/pyntegritydb/cli.py
@@ -1,0 +1,52 @@
+import argparse
+from . import connect, schema, metrics, report
+
+def main():
+    """
+    Función principal de la interfaz de línea de comandos (CLI).
+    """
+    parser = argparse.ArgumentParser(
+        description="Analiza la integridad referencial de una base de datos y genera un reporte."
+    )
+    parser.add_argument(
+        "db_uri", 
+        type=str, 
+        help="La URI de conexión de la base de datos (ej. 'sqlite:///database.db')."
+    )
+    parser.add_argument(
+        "--format", 
+        type=str, 
+        default="cli", 
+        choices=['cli', 'json', 'csv'],
+        help="El formato del reporte de salida."
+    )
+    
+    args = parser.parse_args()
+
+    try:
+        # 1. Conectar a la base de datos
+        print("🔌 Conectando a la base de datos...")
+        engine = connect.create_db_engine(args.db_uri)
+        
+        # 2. Extraer esquema y construir grafo
+        schema_graph = schema.get_schema_graph(engine)
+        
+        if schema_graph.number_of_edges() == 0:
+            print("\nNo se encontraron relaciones de clave foránea para analizar.")
+            return
+
+        # 3. Calcular métricas
+        metrics_df = metrics.analyze_database_completeness(engine, schema_graph)
+        
+        # 4. Generar y mostrar el reporte
+        print("\n📊 Reporte de Integridad Referencial:")
+        final_report = report.generate_report(metrics_df, report_format=args.format)
+        print(final_report)
+
+    except (ValueError, ConnectionError) as e:
+        print(f"\n❌ Error: {e}")
+    except Exception as e:
+        print(f"\n❌ Ocurrió un error inesperado: {e}")
+
+if __name__ == '__main__':
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,24 +1,49 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "pyntegritydb"
 version = "0.1.0"
 authors = [
   { name = "Osvaldo Trujillo", email = "osvaldo.trujillo.ingenieria@gmail.com" },
 ]
-description = ""
+description = "Una biblioteca para medir la calidad de la integridad referencial en bases de datos relacionales."
 readme = "README.md"
-requires-python = ">=3.13"
+requires-python = ">=3.8"
 license = { file = "LICENSE" }
+keywords = ["database", "integrity", "data quality", "sql", "validator"]
 classifiers = [
-    "Programming Language :: Python :: 3",
+    # Estado del proyecto
+    "Development Status :: 4 - Beta",
+
+    # Audiencia y tema
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "Topic :: Database",
+    "Topic :: Software Development :: Quality Assurance",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+
+    # Licencia
     "License :: OSI Approved :: MIT License",
+
+    # Versiones de Python soportadas
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    
+    # Sistema operativo
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "SQLAlchemy==2.0.43",
     "psycopg2-binary==2.9.10",
-    "networkx==3.5",
-    "pandas==2.3.1",
-    "tabulate==0.9.0"
+    "sqlalchemy>=2.0",
+    "networkx>=3.0",
+    "pandas>=2.0",
+    "tabulate>=0.9"
 ]
 
 [project.optional-dependencies]
@@ -37,3 +62,6 @@ Homepage = "https://github.com/osvaldomx/pyntegritydb"
 Repository = "https://github.com/osvaldomx/pyntegritydb"
 Changelog = "https://github.com/osvaldomx/pyntegritydb/releases/tag/v0.2.0"
 Issues = "https://github.com/osvaldomx/pyntegritydb/issues"
+
+[project.scripts]
+pyntegritydb = "pyntegritydb.cli:main"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,60 @@
+import pytest
+from unittest.mock import patch, MagicMock
+import pandas as pd
+import networkx as nx
+
+from pyntegritydb.cli import main
+
+@patch('pyntegritydb.cli.report')
+@patch('pyntegritydb.cli.metrics')
+@patch('pyntegritydb.cli.schema')
+@patch('pyntegritydb.cli.connect')
+@patch('argparse.ArgumentParser.parse_args')
+def test_main_cli_flow(
+    mock_parse_args, mock_connect, mock_schema, mock_metrics, mock_report
+):
+    """
+    Prueba el flujo completo de la CLI, simulando cada módulo.
+    """
+    # 1. Configuración de los mocks
+    # Simular argumentos de línea de comandos
+    mock_parse_args.return_value = MagicMock(db_uri="sqlite:///test.db", format="cli")
+    
+    # Simular un grafo y un dataframe de resultados
+    mock_graph = nx.DiGraph()
+    mock_graph.add_edge("table_a", "table_b")
+    mock_df = pd.DataFrame({'validity_rate': [0.99]})
+
+    # Asignar los valores de retorno a los módulos simulados
+    mock_connect.create_db_engine.return_value = MagicMock()
+    mock_schema.get_schema_graph.return_value = mock_graph
+    mock_metrics.analyze_database_completeness.return_value = mock_df
+    mock_report.generate_report.return_value = "Reporte de prueba"
+
+    # 2. Ejecutar la función principal
+    main()
+
+    # 3. Verificaciones
+    # Verificar que cada módulo fue llamado en el orden correcto
+    mock_connect.create_db_engine.assert_called_once_with("sqlite:///test.db")
+    mock_schema.get_schema_graph.assert_called_once()
+    mock_metrics.analyze_database_completeness.assert_called_once()
+    mock_report.generate_report.assert_called_once_with(mock_df, report_format="cli")
+
+@patch('pyntegritydb.cli.connect.create_db_engine')
+@patch('argparse.ArgumentParser.parse_args')
+def test_main_cli_handles_connection_error(mock_parse_args, mock_create_engine):
+    """
+    Prueba que la CLI maneja correctamente un error de conexión.
+    """
+    # Simular argumentos
+    mock_parse_args.return_value = MagicMock(db_uri="invalid_uri", format="cli")
+    
+    # Simular que la conexión falla
+    mock_create_engine.side_effect = ValueError("Conexión fallida")
+
+    # Ejecutar main y verificar que no se lance una excepción no controlada
+    main()
+
+    # Verificar que se intentó conectar
+    mock_create_engine.assert_called_once_with("invalid_uri")


### PR DESCRIPTION
### Resumen
Este PR introduce el módulo **`cli.py`**, que unifica todos los componentes de la biblioteca (`connect`, `schema`, `metrics`, `report`) en una aplicación de línea de comandos funcional.  завершает

Este es el punto de entrada principal para los usuarios, permitiéndoles analizar una base de datos con un único comando. Utiliza `argparse` para procesar los argumentos, como la URI de la base de datos y el formato del reporte.

### Cambios Clave
- **`pyntegritydb/cli.py`**: Nuevo módulo que orquesta el flujo completo de la aplicación.
- **`tests/test_cli.py`**: Pruebas unitarias que simulan la ejecución de la CLI y verifican que cada módulo interno sea llamado correctamente.

### Cómo Probar
1.  Desde el directorio raíz, puedes ejecutar la aplicación directamente:
    ```bash
    # (Asegúrate de tener una base de datos de prueba, por ejemplo, un archivo .db)
    python -m pyntegritydb.cli "sqlite:///tu_base_de_datos.db" --format cli
    ```
2.  Ejecuta `pytest` para verificar que las pruebas unitarias del flujo simulado pasen. ✅