### PR TITLE
[ADD] test: Add end-to-end integration tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,28 +14,19 @@ requires-python = ">=3.8"
 license = { file = "LICENSE" }
 keywords = ["database", "integrity", "data quality", "sql", "validator"]
 classifiers = [
-    # Estado del proyecto
     "Development Status :: 4 - Beta",
-
-    # Audiencia y tema
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "Topic :: Database",
     "Topic :: Software Development :: Quality Assurance",
     "Topic :: Software Development :: Libraries :: Python Modules",
-
-    # Licencia
     "License :: OSI Approved :: MIT License",
-
-    # Versiones de Python soportadas
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    
-    # Sistema operativo
     "Operating System :: OS Independent",
 ]
 dependencies = [
@@ -44,8 +35,8 @@ dependencies = [
     "networkx>=3.0",
     "pandas>=2.0",
     "tabulate>=0.9",
-    "PyYAML==6.0.2",
-    "matplotlib==3.10.5"
+    "PyYAML>=6.0",
+    "matplotlib>=3.7"
 ]
 
 [project.optional-dependencies]
@@ -69,5 +60,4 @@ Issues = "https://github.com/osvaldomx/pyntegritydb/issues"
 pyntegritydb = "pyntegritydb.cli:main"
 
 [tool.pytest.ini_options]
-# Directorios que pytest debe ignorar durante la búsqueda de pruebas.
 norecursedirs = ["examples", "docs", "scripts"]

--- a/tests/setup_test_db.py
+++ b/tests/setup_test_db.py
@@ -1,0 +1,39 @@
+# tests/setup_test_db.py
+import sqlite3
+
+def create_test_database(db_path="test_db.sqlite"):
+    """Crea y puebla una base de datos SQLite para las pruebas de integración."""
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+
+    # Crear tablas
+    cursor.execute('''
+    CREATE TABLE users (
+        id INTEGER PRIMARY KEY,
+        name TEXT NOT NULL
+    )
+    ''')
+    cursor.execute('''
+    CREATE TABLE orders (
+        order_id INTEGER PRIMARY KEY,
+        user_id INTEGER,
+        product TEXT,
+        FOREIGN KEY (user_id) REFERENCES users (id)
+    )
+    ''')
+
+    # Insertar datos de prueba
+    cursor.execute("INSERT INTO users (id, name) VALUES (1, 'Alice'), (2, 'Bob')")
+    
+    # Datos válidos y una fila huérfana (user_id=99 no existe)
+    cursor.execute("INSERT INTO orders (order_id, user_id, product) VALUES (101, 1, 'Laptop')")
+    cursor.execute("INSERT INTO orders (order_id, user_id, product) VALUES (102, 2, 'Mouse')")
+    cursor.execute("INSERT INTO orders (order_id, user_id, product) VALUES (103, 1, 'Keyboard')")
+    cursor.execute("INSERT INTO orders (order_id, user_id, product) VALUES (104, 99, 'Monitor')") # Fila huérfana
+
+    conn.commit()
+    conn.close()
+    print(f"Base de datos de prueba '{db_path}' creada exitosamente.")
+
+if __name__ == '__main__':
+    create_test_database()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,50 @@
+# tests/test_integration.py
+
+import pytest
+import subprocess
+import os
+from .setup_test_db import create_test_database
+
+DB_PATH = "test_integration_db.sqlite"
+
+@pytest.fixture(scope="module")
+def test_db():
+    """
+    Fixture de Pytest que crea la base de datos antes de las pruebas
+    y la elimina después de que todas las pruebas en el módulo hayan terminado.
+    """
+    create_test_database(DB_PATH)
+    yield
+    os.remove(DB_PATH)
+
+def test_cli_end_to_end_run(test_db):
+    """
+    Ejecuta la CLI como un subproceso contra la base de datos de prueba
+    y verifica que la salida contenga los resultados esperados.
+    """
+    # Construye la URI para la base de datos de prueba
+    db_uri = f"sqlite:///{DB_PATH}"
+    
+    # Ejecuta el comando pyntegritydb desde la línea de comandos
+    result = subprocess.run(
+        ["pyntegritydb", db_uri, "--format", "cli"],
+        capture_output=True,
+        text=True,
+        check=True  # Lanza una excepción si el comando falla
+    )
+    
+    # Verifica que la salida no esté vacía y no contenga errores
+    assert result.stderr == ""
+    output = result.stdout
+    
+    # Verifica los puntos clave del reporte generado
+    assert "Reporte de Integridad Referencial" in output
+    assert "orders" in output  # Nombre de la tabla de origen
+    assert "users" in output   # Nombre de la tabla de destino
+    
+    # Verifica los resultados numéricos esperados
+    # (4 filas en total, 1 huérfana -> 75% de validez)
+    assert "75.00%" in output           # Tasa de Validez
+    assert "1" in output                # Filas Huérfanas
+    assert "4" in output                # Total Filas
+    assert "Relaciones con filas huérfanas: 1" in output # Resumen


### PR DESCRIPTION
### Resumen
Este PR introduce las pruebas de integración (end-to-end) para la biblioteca. Estas pruebas validan el flujo completo de la aplicación, desde la ejecución del comando CLI hasta la generación del reporte final, utilizando una base de datos SQLite real y temporal.

Esto nos da una capa adicional de confianza de que todos los módulos (`connect`, `schema`, `metrics`, `report`, `cli`) funcionan correctamente en conjunto.

### Cambios Clave
- **`tests/test_integration.py`**: Nuevo archivo de prueba que ejecuta la CLI como un subproceso.
- **`tests/setup_test_db.py`**: Script auxiliar para crear y poblar una base de datos SQLite para las pruebas.
- **`pytest.ini` / `pyproject.toml` (si es necesario)**: Se asegura de que la configuración de `pytest` sea compatible con estas nuevas pruebas.

### Cómo Probar
1.  Asegúrate de tener `pytest` instalado.
2.  Ejecuta `pytest` desde el directorio raíz.
3.  `pytest` descubrirá y ejecutará las nuevas pruebas de integración, que crearán y eliminarán automáticamente la base de datos de prueba. Todas las pruebas deben pasar. ✅