### PR TITLE
[ADD] feat: Integrate graph visualization into CLI

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,13 +21,17 @@ def test_main_cli_flow(
     mock_parse_args.return_value = MagicMock(
         db_uri="sqlite:///test.db", 
         format="cli",
-        config=None
+        config=None,
+        visualize=False
     )
     
     # Simular un grafo y un dataframe de resultados
     mock_graph = nx.DiGraph()
     mock_graph.add_edge("table_a", "table_b")
-    mock_df = pd.DataFrame({'validity_rate': [0.99]})
+    mock_df = pd.DataFrame({
+        'referencing_table': ['table_a'],
+        'validity_rate': [0.99]
+    })
 
     # Asignar los valores de retorno a los módulos simulados
     mock_connect.create_db_engine.return_value = MagicMock()
@@ -43,7 +47,6 @@ def test_main_cli_flow(
     mock_connect.create_db_engine.assert_called_once_with("sqlite:///test.db")
     mock_schema.get_schema_graph.assert_called_once()
     mock_metrics.analyze_database_completeness.assert_called_once()
-    # mock_report.generate_report.assert_called_once_with(mock_df, report_format="cli")
     mock_report.generate_report.assert_called_once()
     args, kwargs = mock_report.generate_report.call_args
     assert kwargs['report_format'] == 'cli'
@@ -98,7 +101,8 @@ def test_main_cli_flow_with_config(
         db_uri="sqlite:///test.db", 
         format="cli",
         alerts="[]",
-        config="config.yml"
+        config="config.yml",
+        visualize=False
     )
     
     # Simular datos de retorno
@@ -117,6 +121,10 @@ def test_main_cli_flow_with_config(
     mock_metrics.analyze_database_completeness.return_value = mock_completeness_df
     mock_metrics.analyze_attribute_consistency.return_value = mock_consistency_df
     
+    # Simular un grafo CON relaciones
+    mock_graph = nx.DiGraph()
+    mock_graph.add_edge("orders", "users")
+    mock_schema.get_schema_graph.return_value = mock_graph
 
     # 2. Ejecución
     main()
@@ -168,4 +176,46 @@ def test_main_cli_exits_with_error_on_alerts(
     # Verificar que se llamó a sys.exit con el código de error 1
     mock_alerts.check_thresholds.assert_called_once()
     mock_exit.assert_called_once_with(1)
+
+
+@patch('pyntegritydb.cli.visualize')
+@patch('pyntegritydb.cli.report')
+@patch('pyntegritydb.cli.metrics')
+@patch('pyntegritydb.cli.schema')
+@patch('pyntegritydb.cli.connect')
+@patch('pyntegritydb.cli.config')
+@patch('pyntegritydb.cli.alerts')
+@patch('argparse.ArgumentParser.parse_args')
+def test_main_cli_with_visualize_flag(
+    mock_parse_args, mock_alerts, mock_config, mock_connect, 
+    mock_schema, mock_metrics, mock_report, mock_visualize
+):
+    """Prueba que el módulo de visualización es llamado con el flag --visualize."""
+    mock_parse_args.return_value = MagicMock(
+        db_uri="sqlite:///test.db",
+        format="cli",
+        config=None,
+        visualize=True, # Simula que el flag está activado
+        output_image="test_graph.png"
+    )
+    
+    # Simular datos de retorno necesarios para el flujo
+    mock_graph = nx.DiGraph()
+    mock_graph.add_edge("table_a", "table_b")
+    
+    mock_df = pd.DataFrame({
+        'referencing_table': ['table_a'],
+        'validity_rate': [0.99]
+    })
+    mock_schema.get_schema_graph.return_value = mock_graph
+    mock_metrics.analyze_database_completeness.return_value = mock_df
+
+    main()
+
+    # Verificar que la función de visualización fue llamada con los argumentos correctos
+    mock_visualize.visualize_schema_graph.assert_called_once_with(
+        graph=mock_graph,
+        metrics_df=mock_df,
+        output_path="test_graph.png"
+    )
 


### PR DESCRIPTION
### Resumen
Este PR integra el módulo `visualize` con la interfaz de línea de comandos, haciendo que la generación de gráficos sea una característica accesible para el usuario final. 🎨

Se han añadido dos nuevos argumentos a la CLI:
- `--visualize`: Un flag para activar la creación de la imagen del grafo.
- `--output-image`: Una opción para especificar la ruta y el nombre del archivo de salida.

### Cambios Clave
- **`cli.py`**: Se han añadido los nuevos argumentos y la lógica para llamar al módulo de visualización.
- **`tests/test_cli.py`**: Se ha añadido una prueba unitaria para verificar que la función de visualización es llamada cuando se usa el flag.
- **`tests/test_integration.py`**: La prueba de integración ha sido actualizada para incluir el uso de los nuevos flags y verificar que la imagen se genere correctamente.

### Ejemplo de Uso
```bash
pyntegritydb "sqlite:///database.db" --visualize --output-image my_schema_health.png
```